### PR TITLE
Revert "delete gBn/sConstructorMap"

### DIFF
--- a/transport/HidlBinderSupport.cpp
+++ b/transport/HidlBinderSupport.cpp
@@ -254,6 +254,10 @@ sp<IBinder> getOrCreateCachedBinder(::android::hidl::base::V1_0::IBase* ifacePtr
 
     if (sBnObj == nullptr) {
         auto func = details::getBnConstructorMap().get(descriptor, nullptr);
+        if (!func) {
+            // TODO(b/69122224): remove this static variable when prebuilts updated
+            func = details::gBnConstructorMap->get(descriptor, nullptr);
+        }
         LOG_ALWAYS_FATAL_IF(func == nullptr, "%s getBnConstructorMap returned null for %s",
                             __func__, descriptor.c_str());
 

--- a/transport/HidlPassthroughSupport.cpp
+++ b/transport/HidlPassthroughSupport.cpp
@@ -29,6 +29,10 @@ namespace details {
 
 static sp<IBase> tryWrap(const std::string& descriptor, sp<IBase> iface) {
     auto func = getBsConstructorMap().get(descriptor, nullptr);
+    if (!func) {
+        // TODO(b/69122224): remove this when prebuilts don't reference it
+        func = gBsConstructorMap->get(descriptor, nullptr);
+    }
     if (func) {
         return func(static_cast<void*>(iface.get()));
     }

--- a/transport/InternalStatic.h
+++ b/transport/InternalStatic.h
@@ -28,6 +28,13 @@ namespace hardware {
 namespace details {
 
 // TODO(b/69122224): remove this once no prebuilts reference it
+// deprecated; use getBnConstructorMap instead.
+extern DoNotDestruct<BnConstructorMap> gBnConstructorMap;
+// TODO(b/69122224): remove this once no prebuilts reference it
+// deprecated; use getBsConstructorMap instead.
+extern DoNotDestruct<BsConstructorMap> gBsConstructorMap;
+
+// TODO(b/69122224): remove this once no prebuilts reference it
 extern DoNotDestruct<ConcurrentMap<wp<::android::hidl::base::V1_0::IBase>, SchedPrio>>
         gServicePrioMap;
 // TODO(b/69122224): remove this once no prebuilts reference it

--- a/transport/Static.cpp
+++ b/transport/Static.cpp
@@ -27,6 +27,9 @@ namespace android {
 namespace hardware {
 namespace details {
 
+// Deprecated; kept for ABI compatibility. Use getBnConstructorMap.
+DoNotDestruct<BnConstructorMap> gBnConstructorMap{};
+
 DoNotDestruct<ConcurrentMap<const ::android::hidl::base::V1_0::IBase*,
                             wp<::android::hardware::BHwBinder>>>
         gBnMap{};
@@ -35,6 +38,11 @@ DoNotDestruct<ConcurrentMap<const ::android::hidl::base::V1_0::IBase*,
 DoNotDestruct<ConcurrentMap<wp<::android::hidl::base::V1_0::IBase>, SchedPrio>> gServicePrioMap{};
 DoNotDestruct<ConcurrentMap<wp<::android::hidl::base::V1_0::IBase>, bool>> gServiceSidMap{};
 
+// Deprecated; kept for ABI compatibility. Use getBsConstructorMap.
+DoNotDestruct<BsConstructorMap> gBsConstructorMap{};
+
+// For static executables, it is not guaranteed that gBnConstructorMap are initialized before
+// used in HAL definition libraries.
 BnConstructorMap& getBnConstructorMap() {
     static BnConstructorMap& map = *new BnConstructorMap();
     return map;


### PR DESCRIPTION
 * Legacy (msm8998/sdm660) device blobs need this static variable

This reverts commit e29b2ad2157639fd466644154cde7673b052fa8d.

Change-Id: Ib67da54866d21bd7fc260b5fddcff4df1f05e971